### PR TITLE
update scalyr chart: default to NOT report container metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Once Helm is set up properly, add the repo as follows:
 $ helm repo add codecademy https://codecademy-engineering.github.io/helm-charts
 ```
 
-You can then run `helm search codecademy` to see the charts.
+You can then run `helm search repo codecademy` to see the charts.
 
 ## Contribution Guidelines
 

--- a/charts/scalyr/Chart.yaml
+++ b/charts/scalyr/Chart.yaml
@@ -7,10 +7,7 @@ keywords:
   - monitoring
   - alerting
   - logging
-maintainers:
-  - email: scott@r6by.com
-    name: scottrigby
 name: scalyr
 sources:
   - https://www.scalyr.com/help/install-agent-kubernetes
-version: 0.2.3
+version: 0.2.4

--- a/charts/scalyr/templates/cm.yaml
+++ b/charts/scalyr/templates/cm.yaml
@@ -81,6 +81,6 @@ data:
   agent.json: |
     {
       implicit_metric_monitor: false,
-      implicit_agent_process_metrics_monitor: false,
+      implicit_agent_process_metrics_monitor: false
     }
 {{ end }}

--- a/charts/scalyr/templates/ds.yaml
+++ b/charts/scalyr/templates/ds.yaml
@@ -52,6 +52,8 @@ spec:
                   key: k8s_events_disable
                   optional: true
             {{- end }}
+            - name: SCALYR_REPORT_CONTAINER_METRICS
+              value: {{ .Values.scalyr.config.reportContainerMetrics }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/scalyr/values.yaml
+++ b/charts/scalyr/values.yaml
@@ -70,6 +70,7 @@ scalyr:
       #
       custom:
 
+    reportContainerMetrics: false
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR:
- disables container metric reporting by default, with the ability enable with value params

Container Metrics reports things like CPU usage, memory, etc to Scalyr.
Note that disabling `report_container_metrics` also disables `report_k8s_metrics`:

context | config variable | description
--- | --- | ---
K8s monitor | report_container_metrics | If true, also collect metrics from containers whose logs are monitored.
K8s monitor | report_k8s_metrics | If true and report_container_metrics is also true, then collect Kubernetes system metrics.

See: https://app.scalyr.com/help/monitors/kubernetes
