### PR TITLE
CORE-276 templatize deployment strategy in rails chart

### DIFF
--- a/charts/rails/Chart.yaml
+++ b/charts/rails/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - email: devops@codecademy.com  # pragma: allowlist secret
     name: devops
 name: rails
-version: 2.6.0
+version: 2.7.0

--- a/charts/rails/templates/deployment.yaml
+++ b/charts/rails/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "rails.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.strategy }}
+  strategy:
+{{ toYaml . | indent 4 }}
+{{- end}}
   template:
     metadata:
       labels:

--- a/charts/rails/values.yaml
+++ b/charts/rails/values.yaml
@@ -135,3 +135,17 @@ initContainer:
 
 podDisruptionBudget:
   maxUnavailable: "25%"
+
+
+# Deployment strategy.
+# See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+# See: https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#deploymentstrategy-v1-apps
+# To overwrite the default RollingUpdate:
+#   strategy:
+#     rollingUpdate: null
+#     type: Replace
+strategy:
+  rollingUpdate:
+    maxSurge: 25%
+    maxUnavailable: 25%
+  type: RollingUpdate


### PR DESCRIPTION
Signed-off-by: Brian H. Buchholz <4773480+bhb603@users.noreply.github.com>

This PR:
- Templatizes the deployment strategy in the Rails chart

The impetus is that I need to deploy a Rails deployment running Kafka consumer,
and unlike most deployments, this requires a `Replace` strategy,
see: https://github.com/zendesk/racecar#deploying-to-kubernetes


The default strategy when nothing is specified should be unchanged:
```yaml
strategy:
  rollingUpdate:
    maxSurge: 25%
    maxUnavailable: 25%
  type: RollingUpdate
```
