### PR TITLE
fix rails chart deployment strategy

### DIFF
--- a/charts/rails/Chart.yaml
+++ b/charts/rails/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - email: devops@codecademy.com  # pragma: allowlist secret
     name: devops
 name: rails
-version: 2.7.0
+version: 2.7.1

--- a/charts/rails/templates/deployment.yaml
+++ b/charts/rails/templates/deployment.yaml
@@ -20,9 +20,13 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "rails.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-{{- with .Values.strategy }}
-  strategy:
-{{ toYaml . | indent 4 }}
+    strategy:
+      type: {{ .Values.strategy.type }}
+{{- if eq .Values.strategy.type "RollingUpdate" }}
+      rollingUpdate:
+{{- with .Values.strategy.rollingUpdate }}
+{{ toYaml . | indent 8 }}
+{{- end}}
 {{- end}}
   template:
     metadata:

--- a/charts/rails/templates/deployment.yaml
+++ b/charts/rails/templates/deployment.yaml
@@ -20,12 +20,12 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "rails.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-    strategy:
-      type: {{ .Values.strategy.type }}
+  strategy:
+    type: {{ .Values.strategy.type }}
 {{- if eq .Values.strategy.type "RollingUpdate" }}
-      rollingUpdate:
+    rollingUpdate:
 {{- with .Values.strategy.rollingUpdate }}
-{{ toYaml . | indent 8 }}
+{{ toYaml . | indent 6 }}
 {{- end}}
 {{- end}}
   template:

--- a/charts/rails/values.yaml
+++ b/charts/rails/values.yaml
@@ -142,8 +142,7 @@ podDisruptionBudget:
 # See: https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#deploymentstrategy-v1-apps
 # To overwrite the default RollingUpdate:
 #   strategy:
-#     rollingUpdate: null
-#     type: Replace
+#     type: Recreate
 strategy:
   rollingUpdate:
     maxSurge: 25%


### PR DESCRIPTION
Signed-off-by: Brian H. Buchholz <4773480+bhb603@users.noreply.github.com>

The problem is that deploy strategy has to be EITHER:
```yaml
type: Recreate
```
OR
```yaml
type: RollingUpdate
rollingUpdate:
  maxSurge: x
  maxUnavailable: y
```
And if type=Recreate, kuberenets complains when the `rollingUpdate` params are present.

The previous implementation of this chart, where I just documented to set `rollingUpdate: null`, seemed to work when I used helm directly in this repo:
```
# my-values.yaml
strategy:
  type: Recreate
  rollingUpdate: null
```
```
helm template -f my-values.yaml .
```
produces:
```
  strategy:
    type: Recreate
```

However, in the monolith, when I tried this: https://github.com/codecademy-engineering/Codecademy/commit/577b803f11e2ed6b20edbbda821e8bcf7f3a7783#diff-7856ef33ccbcdb4cd44bc00c201ad2e2db407071cf8e0e89c1a300378f3e2792R179

For some reason the values are not working as expected... somewhere in makefile, helmfile, helm etc, the `rollingUpdate: null` is not overwriting the default rollingUpdate params, and it produces:
```
type: Recreate
rollingUpdate:
  maxSurge: 25%
  maxUnavailable: 25%
```
which is illegal for the k8s api.

Anyway, I think this should fix it.