### PR TITLE
Host Aliases

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.2.0
+version: 1.3.0
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/ci/custom-values.yaml
+++ b/charts/service/ci/custom-values.yaml
@@ -85,3 +85,12 @@ cronJobs:
         cpu: 10m
         memory: 50Mi
     schedule: "* * * * *"
+
+hostAliases:
+  - ip: 0.0.0.0
+    hostnames:
+      - somehost.com
+  - ip: 10.0.0.0
+    hostnames:
+      - anotherhost.com
+      - anotherhost2.com

--- a/charts/service/ci/no-host-values.yaml
+++ b/charts/service/ci/no-host-values.yaml
@@ -1,0 +1,39 @@
+resources:
+  requests:
+    cpu: 5m
+  limits:
+    cpu: 100m
+
+containerPort: 80
+
+env:
+  - name: FOO
+    value: bar
+  - name: POTATO
+    value: potato
+
+envKeyValue:
+  ABCDEF: ghijkl
+  STUFF: things
+  NUMBER: 7
+
+image:
+  command:
+    - nginx-debug
+    - '-g'
+    - 'daemon off;'
+
+annotations:
+  abc: def
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
 {{ toYaml . | indent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -55,6 +55,8 @@ nodeSelector: {}
 
 tolerations: []
 
+hostAliases: []
+
 affinity: {}
 
 volumes: {}


### PR DESCRIPTION
# Overview

Add ability to set host aliases for the service deployment.

This allows us to add entries to the host files for deployments which can be used for events such as resiliency day testing.

## Test Results
I tested this by setting the Monolith service chart to use my local deployment, and added a `hostAliases` block to the rails service. Afterwards, I redeployed by running `aws-vault exec nonprod -- make k8s-deploy -f k8s.mk HELM_RELEASE_NAME=pr-33220` and inspected the new pod.
![image](https://user-images.githubusercontent.com/81973057/198109199-10b9b9dc-6835-4ee3-bc0c-3b8611369c83.png)
![image](https://user-images.githubusercontent.com/81973057/198109266-b5f47d27-f821-4bcd-a422-9500a96b0607.png)

I confirmed the describe didn't reveal it, but I looked at the `/etc/hosts` in the pod and verified it worked by trying to hit the overwrites.

![image](https://user-images.githubusercontent.com/81973057/198109636-66a1d7a3-d6df-46dc-9a6f-16c5302bda8e.png)
![image](https://user-images.githubusercontent.com/81973057/198109657-ec55083a-c60f-46fa-9c59-599116737970.png)

