### PR TITLE
[DEVOPS-5331] Allow selectorLabels in service chart service resource to be overridden via values file

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -38,7 +38,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.4.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.5.0
+version: 1.6.0
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -22,8 +22,11 @@ spec:
     {{- end }}
       labels:
         {{- include "service.selectorLabels" . | nindent 8 }}
+        {{- with .Values.service.selectorLabelOverride }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podLabels }}
-{{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.datadog }}
         tags.datadoghq.com/env: {{ .env }}

--- a/charts/service/templates/service.yaml
+++ b/charts/service/templates/service.yaml
@@ -18,5 +18,11 @@ spec:
       name: {{ .name }}
     {{- end }}
   selector:
-    {{- include "service.selectorLabels" . | nindent 4 }}
+    {{- if .Values.service.selectorLabelOverride }}
+      {{- with .Values.service.selectorLabelOverride }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- else }}
+      {{- include "service.selectorLabels" . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -70,6 +70,7 @@ service:
   enabled: true
   type: ClusterIP
   port: 80
+  selectorLabelOverride: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
Resolves: https://codecademy.atlassian.net/browse/DEVOPS-5331

Allows chart consumer to pass in `service.selectorLabelOverride` in values.yaml file in order to generate custom field selectors for the service resource.