### PR TITLE
Allow serviceAccount annotations to be overridden via values file

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.6.0
+version: 1.7.0
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/serviceaccount.yaml
+++ b/charts/service/templates/serviceaccount.yaml
@@ -7,4 +7,9 @@ metadata:
     {{- include "service.labels" . | nindent 4 }}
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.aws_account_id }}:role/{{ .Values.serviceAccount.role }}
+    {{- if .Values.serviceAccount.annotations }}
+      {{- with .Values.serviceAccount.annotations }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/service/templates/serviceaccount.yaml
+++ b/charts/service/templates/serviceaccount.yaml
@@ -7,9 +7,5 @@ metadata:
     {{- include "service.labels" . | nindent 4 }}
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.aws_account_id }}:role/{{ .Values.serviceAccount.role }}
-    {{- if .Values.serviceAccount.annotations }}
-      {{- with .Values.serviceAccount.annotations }}
-        {{- toYaml . | nindent 4 }}
-      {{- end }}
-    {{- end }}
+    {{- include .Values.serviceAccount.annotations | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Resolves: https://codecademy.atlassian.net/browse/DEVOPS-5373

Usage requires the annotations be in a {} block, and quotes around each key/value rather than the whole line. Example:

```
annotations: { "helm.sh/hook": "pre-install" }
```