### PR TITLE
Correct annotation rendering in service account

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.7.0
+version: 1.7.1
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/serviceaccount.yaml
+++ b/charts/service/templates/serviceaccount.yaml
@@ -7,5 +7,9 @@ metadata:
     {{- include "service.labels" . | nindent 4 }}
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.aws_account_id }}:role/{{ .Values.serviceAccount.role }}
-    {{- include .Values.serviceAccount.annotations | nindent 4 }}
+    {{- if .Values.serviceAccount.annotations }}
+      {{- with .Values.serviceAccount.annotations }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Example from local testing using chartmuseum:

```
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: static-asset-cms
  labels:
    helm.sh/chart: static-asset-cms-1.7.5
    app.kubernetes.io/name: static-asset-cms
    app.kubernetes.io/instance: static-asset-cms
    app.kubernetes.io/managed-by: Helm
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::489726130094:role/static-asset-cms
    helm.sh/hook: pre-install
```