### PR TITLE
Service chart enhancements for portal-app

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.7.7
+version: 1.8.0
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.7.5
+version: 1.7.7
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -56,12 +56,38 @@ spec:
         - name: {{ .Values.initContainer.name }}
           image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
           imagePullPolicy: {{ .Values.initContainer.image.pullPolicy }}
+          {{- with .Values.initContainer.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.initContainer.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.initContainer.env }}
           env:
+          {{- with .Values.initContainer.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.datadog }}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/env']
+            - name: DD_SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/service']
+            - name: DD_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/version']
+          {{- end }}
+          {{- with .Values.initContainer.resources }}
+          resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           securityContext:

--- a/charts/service/templates/jobs.yaml
+++ b/charts/service/templates/jobs.yaml
@@ -1,0 +1,80 @@
+{{- $image := .Values.image.repository -}}
+{{- $tag := .Values.image.tag -}}
+{{- $imagePullPolicy := .Values.image.pullPolicy -}}
+{{- $datadog := .Values.datadog -}}
+{{- $securityContext := .Values.securityContext -}}
+{{- range .Values.jobs }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .name }}
+spec:
+  {{- if .ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- with $datadog }}
+        {{- if and .service .env }}
+        tags.datadoghq.com/enabled: {{ .enabled | quote }}
+        tags.datadoghq.com/env: {{ .env }}
+        tags.datadoghq.com/service: {{ .service }}
+        tags.datadoghq.com/version: {{ .version | quote }}
+        {{- end }}
+        {{- end }}
+    spec:
+      containers:
+        - name: {{ .name }}
+          image: "{{ $image }}:{{ $tag }}"
+          imagePullPolicy: {{ $imagePullPolicy }}
+          command:
+            {{- toYaml .command | nindent 12 }}
+          env:
+            {{- with .env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $datadog }}
+            {{- if and .service .env }}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DATADOG__ENABLED
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/enabled']
+            - name: DATADOG__ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/env']
+            - name: DATADOG__SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/service']
+            - name: DATADOG__VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/version']
+            {{- end }}
+            {{- end }}
+          resources:
+            {{- toYaml .resources | nindent 12 }}
+          securityContext:
+            {{- toYaml $securityContext | nindent 12 }}
+          {{- with .volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .persistentVolumeClaim }}
+          persistentVolumeClaims:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      restartPolicy: {{ .restartPolicy | default "OnFailure" }}
+      {{- with .volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  backoffLimit: 4
+{{- end }}

--- a/charts/service/templates/jobs.yaml
+++ b/charts/service/templates/jobs.yaml
@@ -45,15 +45,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/enabled']
-            - name: DATADOG__ENV
+            - name: DD_ENV
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/env']
-            - name: DATADOG__SERVICE
+            - name: DD_SERVICE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/service']
-            - name: DATADOG__VERSION
+            - name: DD_VERSION
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
@@ -67,7 +67,7 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .persistentVolumeClaim }}
+          {{- with .persistentVolumeClaims }}
           persistentVolumeClaims:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/service/templates/pdb.yaml
+++ b/charts/service/templates/pdb.yaml
@@ -5,12 +5,19 @@ metadata:
   labels:
     {{- include "service.labels" . | nindent 4 }}
 spec:
-{{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-{{- end }}
-{{- if .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- if .Values.podDisruptionBudget }}
+  {{- with .Values.podDisruptionBudget }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- else }}
+  maxUnavailable: 25%
 {{- end }}
   selector:
     matchLabels:
+    {{- if .Values.service.selectorLabelOverride }}
+      {{- with .Values.service.selectorLabelOverride }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- else }}
       {{- include "service.selectorLabels" . | nindent 6 }}
+    {{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -102,7 +102,7 @@ datadog: {}
   # service: service_name
   # version: version
 
-preReleaseJob:
+preReleaseJobs:
   enabled: false
   image:
     repository: alpine
@@ -123,5 +123,3 @@ preReleaseJob:
 initContainer:
   enabled: false
 
-podDisruptionBudget:
-  maxUnavailable: "25%"

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -102,7 +102,7 @@ datadog: {}
   # service: service_name
   # version: version
 
-preReleaseJobs:
+preReleaseJob:
   enabled: false
   image:
     repository: alpine

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -122,4 +122,3 @@ preReleaseJob:
 
 initContainer:
   enabled: false
-


### PR DESCRIPTION
Significant updates include:

* Removed 2 if statements from podDisruptionBudget. Now it will check if `.Values.podDisruptionBudget` is set. If true, we will use that value, otherwise we will provide a default of `maxUnavailable: 25%`.
* Removed podDisruptionBudget default from values.yaml. This maxUnavailable default interfered with any requirement to use minAvailable in subcharts. Now the default is defined in the pdb.yaml, documented in the above bullet point.
* Allow podDisruptionBudget selector labels to be overridden.
* Added jobs.yaml to enable jobs that aren't considered "pre-release" jobs.

Resolves: https://codecademy.atlassian.net/browse/DEVOPS-6440

This has been tested (using `make k8s-template` or the equivalent command) against the following:
  * workspace-service
  * portal-app in monorepo
  * codecademy PR env
  * codecademy zoo env
  * codecademy staging