### PR TITLE
[DEVOPS-6453] Service chart updates for authz-service

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.0
+version: 1.8.2
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -50,6 +50,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.minReadySeconds}}
+      minReadySeconds:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.progressDeadlineSeconds}}
+      progressDeadlineSeconds:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "service.serviceAccountName" . }}
       {{- if .Values.initContainer.enabled }}
       initContainers:


### PR DESCRIPTION
Jira: https://codecademy.atlassian.net/browse/DEVOPS-6453

Unblocks: [Jira](https://codecademy.atlassian.net/browse/DEVOPS-5626) & https://github.com/codecademy-engineering/authz-service/pull/62

Updates to the deployment template to support the following configurations:
1. `minReadySeconds`, a setting that specifies the minimum number of seconds for which a newly created Pod should be running and ready without any of its containers crashing, for it to be considered available ([docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds))
2. `progressDeadlineSeconds`, a setting that denotes the number of seconds the Deployment controller waits before indicating (in the Deployment status) that the Deployment progress has stalled ([docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds))
