### PR TITLE
DEVOPS-6253 follow up fix

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.4
+version: 1.8.5
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -11,6 +11,14 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.minReadySeconds}}
+  minReadySeconds:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.progressDeadlineSeconds}}
+  progressDeadlineSeconds:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
   {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -48,14 +56,6 @@ spec:
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.minReadySeconds}}
-      minReadySeconds:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.progressDeadlineSeconds}}
-      progressDeadlineSeconds:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "service.serviceAccountName" . }}


### PR DESCRIPTION
Follow up to #99 that moves newly introduced configs from `.spec.template.spec` to `.spec` level.