### PR TITLE
Bump HorizontalPodAutoscaler to use apiVersion v2

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.8
+version: 1.8.9
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.7
+version: 1.8.8
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.9
+version: 1.8.10
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/autoscale.yaml
+++ b/charts/service/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "service.fullname" . }}


### PR DESCRIPTION
v2beta2 was deprecated in Kubernetes 1.23 (Documented [here](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#horizontalpodautoscaler-v2-graduates-to-ga))

Resolves: https://codecademy.atlassian.net/browse/DEVOPS-6525