### PR TITLE
remove labels from pre-release-job pod spec

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.7
+version: 1.8.8
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/pre-release-job.yaml
+++ b/charts/service/templates/pre-release-job.yaml
@@ -19,7 +19,6 @@ spec:
     metadata:
       name: {{ include "service.fullname" . }}-pre-release-job
       labels:
-        {{- include "service.labels" . | nindent 8 }}
         {{- with .Values.datadog }}
         tags.datadoghq.com/env: {{ .env }}
         tags.datadoghq.com/service: {{ .service }}

--- a/charts/service/templates/pre-release-job.yaml
+++ b/charts/service/templates/pre-release-job.yaml
@@ -15,6 +15,9 @@ metadata:
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
+  {{- if .ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       name: {{ include "service.fullname" . }}-pre-release-job


### PR DESCRIPTION
If the service labels are added to the pod-spec for pre-release job, then the PodDisruptionBudget for the app will get confused about its selector labels and not allow disruptions.

Looks like pbs is the only app that utilizes a pre-release-job

Adding `ttlSecondsAfterFinished` to the pre-release-job as well.