### PR TITLE
DEVOPS-7129 - Fix horizontal pod autoscaler version EOL k8s 1.26

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.8
+version: 1.8.9
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/autoscale.yaml
+++ b/charts/service/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "service.fullname" . }}


### PR DESCRIPTION
Resolves: DEVOPS-7129

We needed to update our Helm Charts to use autoscaler/v2 instead of deprecated version autoscaler/v2beta2. This PR resolves this issue. This should not break anything in production as its running k8s version 1.25. autoscaler/v2 has been supported since k8s version 1.23.

Reference documents:
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26
https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-the-v2beta2-horizontalpodautoscaler-api

> Removal of the v2beta2 HorizontalPodAutoscaler API
The autoscaling/v2beta2 API version of HorizontalPodAutoscaler [will no longer be served in v1.26](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126). Users should migrate manifests and API clients to use the autoscaling/v2 API version, available since v1.23.