### PR TITLE
[CCINFRA-7926] Extend chart to allow setting variables for datadog source code integration

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.17
+version: 1.8.18
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/ci/with-datadog-values.yaml
+++ b/charts/service/ci/with-datadog-values.yaml
@@ -1,0 +1,10 @@
+service:
+  enabled: false
+
+datadog:
+  env: test
+  service: test-service
+  version: 1.2.3
+  git:
+    repositoryUrl: https://github.com/codecademy-engineering/helm-charts
+    commitSha: 1234567890abcdef

--- a/charts/service/templates/cronjob.yaml
+++ b/charts/service/templates/cronjob.yaml
@@ -62,6 +62,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+            {{- with .git }}
+            - name: DD_GIT_REPOSITORY_URL
+              value: {{ .repositoryUrl }}
+            - name: DD_GIT_COMMIT_SHA
+              value: {{ .commitSha }}
+            {{- end }}
             {{- end }}
             {{- if .envFromSecret }}
             envFrom:

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -98,6 +98,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+            {{- with .git }}
+            - name: DD_GIT_REPOSITORY_URL
+              value: {{ .repositoryUrl }}
+            - name: DD_GIT_COMMIT_SHA
+              value: {{ .commitSha }}
+            {{- end }}
           {{- end }}
           {{- with .Values.initContainer.resources }}
           resources:
@@ -141,6 +147,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+            {{- with .git }}
+            - name: DD_GIT_REPOSITORY_URL
+              value: {{ .repositoryUrl }}
+            - name: DD_GIT_COMMIT_SHA
+              value: {{ .commitSha }}
+            {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.envKeyValue }}
             - name: {{ $key }}

--- a/charts/service/templates/jobs.yaml
+++ b/charts/service/templates/jobs.yaml
@@ -63,6 +63,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+            {{- with .git }}
+            - name: DD_GIT_REPOSITORY_URL
+              value: {{ .repositoryUrl }}
+            - name: DD_GIT_COMMIT_SHA
+              value: {{ .commitSha }}
+            {{- end }}
             {{- end }}
             {{- end }}
           {{- if .envFromSecret }}

--- a/charts/service/templates/pre-release-job.yaml
+++ b/charts/service/templates/pre-release-job.yaml
@@ -60,6 +60,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+            {{- with .git }}
+            - name: DD_GIT_REPOSITORY_URL
+              value: {{ .repositoryUrl }}
+            - name: DD_GIT_COMMIT_SHA
+              value: {{ .commitSha }}
+            {{- end }}
           {{- end }}
   backoffLimit: {{ .Values.preReleaseJob.backoffLimit }}
 {{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -105,6 +105,9 @@ datadog: {}
   # env: production
   # service: service_name
   # version: version
+  # git: {} see below for valid fields
+  #   repositoryUrl: https://github.com/codecademy-engineering/my-repo
+  #   commitSha: valid git commit sha for repositoryUrl
 
 preReleaseJob:
   enabled: false


### PR DESCRIPTION
Resolves: [CCINFRA-7926]

# Overview
- Adds new `git` sub map in `.Values.datadog` map
- New subfields include `git.repositoryUrl` and `git.commitSha`
- This will support adding variables that [enable source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=go) with datadog

[CCINFRA-7926]: https://skillsoftdev.atlassian.net/browse/CCINFRA-7926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ