### PR TITLE
opentelemetry values (to deprecate datadog later)

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.17
+version: 1.8.18
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/ci/custom-values.yaml
+++ b/charts/service/ci/custom-values.yaml
@@ -170,7 +170,7 @@ persistentVolumeClaims:
       name: standard
     storage: 1Gi
 
-datadog:
+otel:
   service: foobar
   version: foo
   env: bar

--- a/charts/service/ci/custom-values.yaml
+++ b/charts/service/ci/custom-values.yaml
@@ -170,6 +170,11 @@ persistentVolumeClaims:
       name: standard
     storage: 1Gi
 
+datadog:
+  service: foobar
+  version: foo
+  env: bar
+
 otel:
   service: foobar
   version: foo

--- a/charts/service/ci/custom-values.yaml
+++ b/charts/service/ci/custom-values.yaml
@@ -169,3 +169,8 @@ persistentVolumeClaims:
         - ReadWriteOnce
       name: standard
     storage: 1Gi
+
+datadog:
+  service: foobar
+  version: foo
+  env: bar

--- a/charts/service/ci/keda-values.yaml
+++ b/charts/service/ci/keda-values.yaml
@@ -107,4 +107,4 @@ keda:
     - type: memory
       metricType: Utilization
       metadata:
-        value: "100"
+        value: "80"

--- a/charts/service/ci/keda-values.yaml
+++ b/charts/service/ci/keda-values.yaml
@@ -105,6 +105,6 @@ keda:
             periodSeconds: 15
   triggers:
     - type: memory
-      metricType: Utilization
+      metricType: AverageValue
       metadata:
         value: "80"

--- a/charts/service/ci/keda-values.yaml
+++ b/charts/service/ci/keda-values.yaml
@@ -105,6 +105,10 @@ keda:
             periodSeconds: 15
   triggers:
     - type: memory
+      metricType: Utilization
+      metadata:
+        value: "100"
+    - type: custom
       metricType: AverageValue
       metadata:
-        value: "80"
+        value: "50"

--- a/charts/service/templates/cronjob.yaml
+++ b/charts/service/templates/cronjob.yaml
@@ -7,6 +7,7 @@
 {{- $parentEnvKeyValue := .Values.envKeyValue -}}
 {{- $parentEnv := .Values.env -}}
 {{- $datadog := .Values.datadog -}}
+{{- $otel := .Values.otel -}}
 {{- range .Values.cronJobs }}
 ---
 apiVersion: batch/v1
@@ -62,6 +63,24 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+            {{- end }}
+            {{- with $otel }}
+            - name: OTEL_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/env']
+            - name: OTEL_SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/service']
+            - name: OTEL_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/version']
             {{- end }}
             {{- if .envFromSecret }}
             envFrom:

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -10,6 +10,11 @@ metadata:
     tags.datadoghq.com/service: {{ .service }}
     tags.datadoghq.com/version: {{ .version | quote }}
     {{- end }}
+    {{- with .Values.otel }}
+    opentelemetry/env: {{ .env }}
+    opentelemetry/service: {{ .service }}
+    opentelemetry/version: {{ .version | quote }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- with .Values.minReadySeconds}}
@@ -45,6 +50,11 @@ spec:
         tags.datadoghq.com/env: {{ .env }}
         tags.datadoghq.com/service: {{ .service }}
         tags.datadoghq.com/version: {{ .version | quote }}
+        {{- end }}
+        {{- with .Values.otel }}
+        opentelemetry/env: {{ .env }}
+        opentelemetry/service: {{ .service }}
+        opentelemetry/version: {{ .version | quote }}
         {{- end }}
       {{- with .Values.annotations }}
       annotations:
@@ -99,6 +109,24 @@ spec:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
           {{- end }}
+          {{- with .Values.otel }}
+            - name: OTEL_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/env']
+            - name: OTEL_SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/service']
+            - name: OTEL_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/version']
+          {{- end }}
           {{- with .Values.initContainer.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -141,6 +169,24 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+          {{- end }}
+          {{- with .Values.otel }}
+            - name: OTEL_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/env']
+            - name: OTEL_SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/service']
+            - name: OTEL_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/version']
           {{- end }}
           {{- range $key, $value := .Values.envKeyValue }}
             - name: {{ $key }}

--- a/charts/service/templates/jobs.yaml
+++ b/charts/service/templates/jobs.yaml
@@ -2,6 +2,7 @@
 {{- $tag := .Values.image.tag -}}
 {{- $imagePullPolicy := .Values.image.pullPolicy -}}
 {{- $datadog := .Values.datadog -}}
+{{- $otel := .Values.otel -}}
 {{- $securityContext := .Values.securityContext -}}
 {{- $parentEnvKeyValue := .Values.envKeyValue -}}
 {{- $parentEnv := .Values.env -}}
@@ -23,6 +24,13 @@ spec:
         tags.datadoghq.com/env: {{ .env }}
         tags.datadoghq.com/service: {{ .service }}
         tags.datadoghq.com/version: {{ .version | quote }}
+        {{- end }}
+        {{- end }}
+        {{- with $otel }}
+        {{- if and .service .env }}
+        opentelemetry/env: {{ .env }}
+        opentelemetry/service: {{ .service }}
+        opentelemetry/version: {{ .version | quote }}
         {{- end }}
         {{- end }}
     spec:
@@ -60,6 +68,26 @@ spec:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/service']
             - name: DD_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/version']
+            {{- end }}
+            {{- end }}
+            {{- with $otel }}
+            {{- if and .service .env }}
+            - name: OTEL_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/env']
+            - name: OTEL_SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['tags.datadoghq.com/service']
+            - name: OTEL_VERSION
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']

--- a/charts/service/templates/pre-release-job.yaml
+++ b/charts/service/templates/pre-release-job.yaml
@@ -10,6 +10,11 @@ metadata:
     tags.datadoghq.com/service: {{ .service }}
     tags.datadoghq.com/version: {{ .version | quote }}
     {{- end }}
+    {{- with .Values.otel }}
+    opentelemetry/env: {{ .env }}
+    opentelemetry/service: {{ .service }}
+    opentelemetry/version: {{ .version | quote }}
+    {{- end }}
   annotations:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-weight": "0"
@@ -26,6 +31,11 @@ spec:
         tags.datadoghq.com/env: {{ .env }}
         tags.datadoghq.com/service: {{ .service }}
         tags.datadoghq.com/version: {{ .version | quote }}
+        {{- end }}
+        {{- with .Values.otel }}
+        opentelemetry/env: {{ .env }}
+        opentelemetry/service: {{ .service }}
+        opentelemetry/version: {{ .version | quote }}
         {{- end }}
     spec:
       restartPolicy: Never
@@ -60,6 +70,24 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['tags.datadoghq.com/version']
+          {{- end }}
+          {{- with .Values.otel }}
+            - name: OTEL_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: OTEL_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/env']
+            - name: OTEL_SERVICE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/service']
+            - name: OTEL_VERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['opentelemetry/version']
           {{- end }}
   backoffLimit: {{ .Values.preReleaseJob.backoffLimit }}
 {{- end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -102,6 +102,7 @@ serviceAccount:
   name: ""
 
 datadog: {}
+otel: {}
   # env: production
   # service: service_name
   # version: version


### PR DESCRIPTION
adding opentelemetry values to helm charts

will deprecate the datadog values in a later commit after all apps are converted to otel