### PR TITLE
add back datadog labels for apm/infra

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: service
 description: A generic k8s service chart
 type: application
-version: 1.8.18
+version: 1.8.19
 maintainers:
   - email: devops@codecademy.com
     name: devops

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -11,9 +11,9 @@ metadata:
     tags.datadoghq.com/version: {{ .version | quote }}
     {{- end }}
     {{- with .Values.otel }}
-    opentelemetry/env: {{ .env }}
-    opentelemetry/service: {{ .service }}
-    opentelemetry/version: {{ .version | quote }}
+    tags.datadoghq.com/env: {{ .env }}
+    tags.datadoghq.com/service: {{ .service }}
+    tags.datadoghq.com/version: {{ .version | quote }}
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -52,9 +52,9 @@ spec:
         tags.datadoghq.com/version: {{ .version | quote }}
         {{- end }}
         {{- with .Values.otel }}
-        opentelemetry/env: {{ .env }}
-        opentelemetry/service: {{ .service }}
-        opentelemetry/version: {{ .version | quote }}
+        tags.datadoghq.com/env: {{ .env }}
+        tags.datadoghq.com/service: {{ .service }}
+        tags.datadoghq.com/version: {{ .version | quote }}
         {{- end }}
       {{- with .Values.annotations }}
       annotations:


### PR DESCRIPTION
these labels are needed to connect infra metrics to the apm dashboard